### PR TITLE
update package version, change update to return the value in the firs…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This is an external dialect for [knex](https://github.com/tgriesser/knex). This 
 Currently, this dialect has limited functionality compared to the Knex built-in dialects. Below are some of the limitations:
 
 - No streaming support
+- Updates return the value of the first column in that row. Make sure your identifier is the first column in the table. The returning option does not work on updates. 
 - Possibly other missing functionality
-- Uses a pool for all connections
 - Journaling must be handled separately. After a migration is ran journaling can be configured on the newly created tables. I recommend using the schema utility in the i access client solutions software. 
 
 ## Installing

--- a/dist/index.js
+++ b/dist/index.js
@@ -392,8 +392,9 @@ var DB2Client = class extends import_knex.default.Client {
         obj.response = { rows, rowCount: rows.length };
       }
     } else {
+      const connection = await pool.connect();
+      await connection.beginTransaction();
       try {
-        const connection = await pool.connect();
         const statement = await connection.createStatement();
         await statement.prepare(obj.sql);
         console.log({ obj });
@@ -409,7 +410,6 @@ var DB2Client = class extends import_knex.default.Client {
             rowCount: result.length
           };
         } else if (method === "update") {
-          console.log(this.queryCompiler);
           let returningSelect = obj.sql.replace("update", "select * from ");
           returningSelect = returningSelect.replace("where", "and");
           returningSelect = returningSelect.replace("set", "where");
@@ -420,14 +420,18 @@ var DB2Client = class extends import_knex.default.Client {
             await selectStatement.bind(obj.bindings);
           }
           const selected = await selectStatement.execute();
-          console.log(selected.columns);
-          obj.response = { rows: selected, rowCount: selected.length };
+          obj.response = { rows: selected.map(
+            (row) => selected.columns.length > 0 ? row[selected.columns[0].name] : row
+          ), rowCount: selected.length };
         } else {
           obj.response = { rows: result, rowCount: result.length };
         }
       } catch (err) {
         console.error(err);
+        await connection.rollback();
         throw new Error(err);
+      } finally {
+        await connection.commit();
       }
     }
     return obj;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bdkinc/knex-ibmi",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Knex dialect for IBMi",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
…t column of the updated row

I do not like this but it works better with the feathers knex Adapter. Long term I hope IBM adds the same functionality that we use on inserts. Right now we make one query for inserts that returns the appropriate values. With an Update we are actually making 2 separate queries, an UPDATE followed by a SELECT