### PR TITLE
fix npm bin path for ibmi-migrations CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "/dist"
   ],
   "bin": {
-    "ibmi-migrations": "./dist/cli.cjs"
+    "ibmi-migrations": "dist/cli.cjs"
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
## Summary
- update `package.json` bin entry from `./dist/cli.cjs` to `dist/cli.cjs`
- this avoids npm auto-correct stripping the `ibmi-migrations` bin field during publish

## Why
During `npm publish --dry-run`, npm warned that the bin path was invalid and removed it from the publish metadata. This change keeps the CLI command consistently available after install.